### PR TITLE
Fix XML conversion for a single result

### DIFF
--- a/lib/WWW/Namecheap/Domain.pm
+++ b/lib/WWW/Namecheap/Domain.pm
@@ -88,8 +88,12 @@ sub check {
     );
     
     return unless $xml;
-    
-    foreach my $entry (@{$xml->{CommandResponse}->{DomainCheckResult}}) {
+
+    my $result = $xml->{CommandResponse}->{DomainCheckResult};
+    # XML returns a hashref if only one returned value, otherwise an array
+    $result = [$result] if (ref $result eq 'HASH');
+
+    foreach my $entry (@$result) {
         unless ($domains{$entry->{Domain}}) {
             Carp::carp("Unexpected domain found: $entry->{Domain}");
             next;


### PR DESCRIPTION
Simple XML parsers generally return single results as a hashref,
whereas multiple results will be returned in an arrayref. Fix to
handle both.

Fixes #3.

Signed-off-by: Nick Andrew <nick@nick-andrew.net>